### PR TITLE
BREAKING CHANGE: Prefer to use add_subdirectory over include(tolc.cma…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Directories
 !.github
 !tests
+!tools

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 # Except these
 # Files
 !.gitignore
-!tolc.cmake
+!CMakeLists.txt
 !README.md
+!tolc.cmake
 
 # Directories
 !.github

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 
 # Directories
 !.github
+!cmake
 !tests
 !tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+project(BootstrapTolc VERSION 0.1)
+
+set(tolc_bootstrap_dir
+  ${CMAKE_CURRENT_LIST_DIR}
+  CACHE
+    PATH
+  "The path to the bootstrap tolc directory")
+
+# Internal function
+function(_tolc_fetch_release content_name)
+  set(supportedPlatforms "Linux;Darwin")
+  if(${CMAKE_HOST_SYSTEM_NAME} IN_LIST supportedPlatforms)
+    # All fetchcontent stuff uses lowercase names
+    string(TOLOWER "${content_name}" content)
+
+    include(${tolc_bootstrap_dir}/cmake/GithubHelpers.cmake)
+    _tolc_fetch_asset_from_github(
+      FETCH_VARIABLE
+        ${content}
+      USER
+        Tolc-Software
+      REPOSITORY
+        tolc-beta
+      TAG
+        beta-release
+      ASSET_NAME
+        tolc-${CMAKE_HOST_SYSTEM_NAME}-beta.tar.gz
+      CODE_DIR
+        ${tolc_bootstrap_dir}/tools)
+    set(${content}_SOURCE_DIR ${${content}_SOURCE_DIR} PARENT_SCOPE)
+  else()
+    string(REPLACE ";" ", " formatedPlatforms ${supportedPlatforms})
+    message(FATAL_ERROR "${CMAKE_HOST_SYSTEM_NAME} is currently not supported by tolc. The currently supported platforms are [${formatedPlatforms}].")
+  endif()
+endfunction()
+
+macro(get_tolc)
+  _tolc_fetch_release(tolc_entry)
+
+  set(tolc_ROOT ${tolc_entry_SOURCE_DIR})
+  find_package(
+    tolc
+    CONFIG
+    PATHS
+    ${tolc_ROOT}
+    REQUIRED
+    NO_DEFAULT_PATH)
+endmacro()

--- a/README.md
+++ b/README.md
@@ -8,34 +8,29 @@ This `CMake` module allows you to download the beta release of `tolc` to then ge
 
 ## Installation ##
 
-The only file that is needed is the `tolc.cmake` module located in the root of this repository.
+Clone and use `add_subdirectory(path/to/bootstrap)` within your project.
 
-You could also download it automatically via `CMake`:
+You can also download it automatically via `CMake`:
 
 ```cmake
-# Download automatically, you can also just copy the tolc.cmake file
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/tolc.cmake")
-  message(STATUS "Downloading tolc.cmake from https://github.com/Tolc-Software/bootstrap-tolc-cmake")
-  file(
-    DOWNLOAD
-      "https://github.com/Tolc-Software/bootstrap-tolc-cmake/raw/main/tolc.cmake"
-      "${CMAKE_BINARY_DIR}/tolc.cmake"
-    TLS_VERIFY
-      ON
-  )
-endif()
+include(FetchContent)
+FetchContent_Declare(
+  tolc_bootstrap
+  GIT_REPOSITORY https://github.com/Tolc-Software/bootstrap-tolc-cmake
+  GIT_TAG        main
+)
 
-include(${CMAKE_BINARY_DIR}/tolc.cmake)
+FetchContent_MakeAvailable(tolc_bootstrap)
 ```
 
 ## Usage ##
 
-`tolc.cmake` only provides the function `get_tolc()` which downloads and finds the latest release of `tolc`.
+The bootstrap script only provides the function `get_tolc()` which downloads the latest release of `tolc`.
 
 A full example:
 
 ```cmake
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.15)
 
 project(bootstrap-tolc-cmake)
 
@@ -43,8 +38,14 @@ project(bootstrap-tolc-cmake)
 add_library(bootstrap src/Boot/bootstrap.cpp)
 target_include_directories(bootstrap PUBLIC include)
 
-# Assumes tolc.cmake is next to this file or in CMAKE_MODULES_PATH
-include(tolc.cmake)
+include(FetchContent)
+FetchContent_Declare(
+  tolc_bootstrap
+  GIT_REPOSITORY https://github.com/Tolc-Software/bootstrap-tolc-cmake
+  GIT_TAG        main
+)
+
+FetchContent_MakeAvailable(tolc_bootstrap)
 # Download and uses find_package to locate tolc
 get_tolc()
 

--- a/cmake/GithubHelpers.cmake
+++ b/cmake/GithubHelpers.cmake
@@ -1,0 +1,87 @@
+include_guard()
+
+# Download an asset from github and set the source directory to ${FETCH_VARIABLE}_SOURCE_DIR
+# This allows for asset id based fetch, i.e. whenever the source is updated, it will be refetched
+# Args:
+#   FETCH_VARIABLE - variable to populate
+#   USER - Github user account
+#   REPOSITORY - Github repository name
+#   TAG - Release tag, e.g. v1.0
+#   ASSET_NAME - Asset to download from the tagged release, e.g. dist.tar.gz
+#   CODE_DIR - Directory of the python code that will be used to get the asset id
+function(_tolc_fetch_asset_from_github)
+  # Define the supported set of keywords
+  set(prefix ARG)
+  set(noValues)
+  set(singleValues FETCH_VARIABLE USER REPOSITORY TAG ASSET_NAME CODE_DIR)
+  set(multiValues)
+  # Process the arguments passed in
+  cmake_parse_arguments(${prefix} "${noValues}" "${singleValues}"
+                        "${multiValues}" ${ARGN})
+
+  find_package(Python3 REQUIRED)
+  # Set up virtualenv for the requirements
+  set(virtualenv ${CMAKE_CURRENT_BINARY_DIR}/tolc/bootstrap/venv)
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -m venv ${virtualenv}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE result)
+
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Something went wrong setting up a virtualenv. Exit code: ${result}")
+  endif()
+
+  set(virtualenv_python ${virtualenv}/bin/python)
+  set(python_pip_args -m pip install -r ${ARG_CODE_DIR}/requirements.txt)
+  execute_process(
+    COMMAND ${virtualenv_python} ${python_pip_args}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE result)
+
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Something went wrong downloading dependencies. Exit code: ${result}")
+  endif()
+
+  set(python_args
+    ${ARG_CODE_DIR}/get_release_id.py
+      --user
+      ${ARG_USER}
+      --repository
+      ${ARG_REPOSITORY}
+      --tag
+      ${ARG_TAG}
+      --asset-name
+      ${ARG_ASSET_NAME})
+  execute_process(
+    COMMAND ${virtualenv_python} ${python_args}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE asset_id)
+
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Something went wrong trying to find the asset id. Exit code: ${result}. Output: ${asset_id}")
+  endif()
+
+  message(
+    STATUS "Fetching asset ${ARG_USER}/${ARG_REPOSITORY}/releases/assets/${asset_id}")
+  include(FetchContent)
+  FetchContent_Declare(
+    ${ARG_FETCH_VARIABLE}
+    URL https://api.github.com/repos/${ARG_USER}/${ARG_REPOSITORY}/releases/assets/${asset_id}
+    HTTP_HEADER "Accept: application/octet-stream")
+  FetchContent_Populate(${ARG_FETCH_VARIABLE})
+
+  # Note that things get set on the lowercase version of the input variable
+  string(TOLOWER ${ARG_FETCH_VARIABLE} lcName)
+  if(NOT ${lcName}_POPULATED)
+    FetchContent_Populate(${ARG_FETCH_VARIABLE})
+  endif()
+
+  # Export the source directory
+  set(${lcName}_SOURCE_DIR
+      ${${lcName}_SOURCE_DIR}
+      PARENT_SCOPE)
+  set(${lcName}_BINARY_DIR
+      ${${lcName}_BINARY_DIR}
+      PARENT_SCOPE)
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is a test for the bootstrap script in this repository.
 # It is NOT meant to be used by consumers
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.15)
 
 project(bootstrap-tolc-cmake)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(bootstrap src/Boot/bootstrap.cpp)
 target_include_directories(bootstrap PUBLIC include)
 
 get_filename_component(rootDir ${PROJECT_SOURCE_DIR} DIRECTORY)
-include(${rootDir}/tolc.cmake)
+add_subdirectory(${rootDir} bootstrap)
 get_tolc()
 
 # Creates the target bootstrap_python that can be imported with python

--- a/tolc.cmake
+++ b/tolc.cmake
@@ -1,38 +1,4 @@
 include_guard()
 
-# Internal function
-function(_fetch_tolc contentName)
-  set(supportedPlatforms "Linux;Darwin")
-  if(${CMAKE_HOST_SYSTEM_NAME} IN_LIST supportedPlatforms)
-    include(FetchContent)
-
-    # All fetchcontent stuff uses lowercase names
-    string(TOLOWER "${contentName}" content)
-
-    FetchContent_Declare(
-      ${content}
-      URL https://github.com/Tolc-Software/tolc-beta/releases/download/beta-release/tolc-${CMAKE_HOST_SYSTEM_NAME}-beta.tar.gz
-    )
-
-    FetchContent_Populate(${content})
-    message(STATUS "source: ${${content}_SOURCE_DIR}")
-    message(STATUS "binary: ${${content}_BINARY_DIR}")
-    set(${content}_SOURCE_DIR ${${content}_SOURCE_DIR} PARENT_SCOPE)
-  else()
-    string(REPLACE ";" ", " formatedPlatforms ${supportedPlatforms})
-    message(FATAL_ERROR "${CMAKE_HOST_SYSTEM_NAME} is currently not supported by tolc. The currently supported platforms are [${formatedPlatforms}].")
-  endif()
-endfunction()
-
-macro(get_tolc)
-  _fetch_tolc(tolc_entry)
-
-  set(tolc_ROOT ${tolc_entry_SOURCE_DIR})
-  find_package(
-    tolc
-    CONFIG
-    PATHS
-    ${tolc_ROOT}
-    REQUIRED
-    NO_DEFAULT_PATH)
-endmacro()
+message(FATAL_ERROR
+  "Deprecated: Download and use bootstrap-tolc via FetchContent instead of downloading tolc.cmake.")

--- a/tools/get_release_id.py
+++ b/tools/get_release_id.py
@@ -1,0 +1,64 @@
+"""
+Brief:               Get a particular release asset id from github
+                     Returns a non-zero exit code if it doesn't find the asset id
+
+File name:           get_release_id.py
+Author:              Simon Rydell
+Python Version:      3.8
+"""
+
+import requests
+import argparse
+import sys
+
+
+def parseArguments():
+    parser = argparse.ArgumentParser(
+        description="Get a particular release asset id from github"
+    )
+    for arg, description in [
+        ("--user", "Github user who owns the repository"),
+        ("--repository", "Repository name to search"),
+        ("--tag", "The release tag to search for, e.g. v0.1"),
+        ("--asset-name", "The asset name to search for, e.g. linux-release.tar.gz"),
+    ]:
+        parser.add_argument(
+            arg, type=str, required=True, help=description,
+        )
+    return parser.parse_args()
+
+
+def main():
+    args = parseArguments()
+    url = f"https://@api.github.com/repos/{args.user}/{args.repository}/releases"
+    req = requests.get(url)
+
+    response = req.json()
+    if "message" in response:
+        # Github just issues a message when something goes wrong
+        # Since this could be anything, just print it out and exit
+        print(response)
+        sys.exit(1)
+
+    found_tag = False
+    for release in response:
+        if release["tag_name"] == args.tag:
+            found_tag = True
+            for asset in release["assets"]:
+                if asset["name"] == args.asset_name:
+                    print(asset["id"])
+                    sys.exit()
+
+    if not found_tag:
+        print(f"Did not find the tag provided: {args.tag}", file=sys.stderr)
+    else:
+        print(
+            f"Did not find the release asset provided: {args.asset_name}",
+            file=sys.stderr,
+        )
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.10
+requests==2.24.0
+urllib3==1.25.9


### PR DESCRIPTION
…ke). Automatically download the latest beta release whenever it is uploaded.

* Added dependency on python3 (not an issue since tolc only supports translating to python so already a dependency)

* Automatically create a virtualenv

* Use virtualenv to install requests and run a python script which gets the id of the latest beta release

* The release id will be matched to a fetchcontent variable, which makes it update whenever the release id changes